### PR TITLE
refactor layout to separate canvas and controls

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -4,7 +4,7 @@
   height: 100vh;
 }
 
-.sceneContainer {
+.stage {
   position: absolute;
   top: 0;
   left: 0;
@@ -12,7 +12,7 @@
   height: 100%;
 }
 
-.controlsOverlay {
+.controls {
   position: absolute;
   top: 20px;
   right: 20px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,19 +10,19 @@ const App = () => {
   const [control, setControl] = useState<SceneControl | null>(null);
 
   return (
-    <div className={styles.app}>
-      <div className={styles.sceneContainer}>
+    <main className={styles.app}>
+      <section className={styles.stage}>
         <Canvas camera={{ position: [0, 0, 5], fov: 60 }}>
           <Suspense fallback={null}>
             <AudioVisualizer control={control} />
           </Suspense>
         </Canvas>
-      </div>
+      </section>
 
-      <div className={styles.controlsOverlay}>
+      <section className={styles.controls}>
         <AudioSessionControls onSceneControl={setControl} />
-      </div>
-    </div>
+      </section>
+    </main>
   );
 };
 


### PR DESCRIPTION
## Summary
- encapsulate canvas in dedicated stage section
- keep session controls outside visualization canvas

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_b_68b3b4c6c7c8832fbec8af118621fdea