### PR TITLE
Streamline scene control and styling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -122,20 +122,4 @@ const LoadingSpinner: React.FC = () => (
   </div>
 );
 
-const GlobalStyles = () => (
-  <style>{`
-    .bg-grid-pattern {
-      background-image: linear-gradient(to right, rgba(107, 114, 128, 0.2) 1px, transparent 1px), linear-gradient(to bottom, rgba(107, 114, 128, 0.2) 1px, transparent 1px);
-      background-size: 40px 40px;
-    }
-  `}</style>
-);
-
-const AppWithStyles: React.FC = () => (
-  <>
-    <GlobalStyles />
-    <App />
-  </>
-);
-
-export default AppWithStyles;
+export default App;

--- a/src/components/AudioSessionControls.tsx
+++ b/src/components/AudioSessionControls.tsx
@@ -31,21 +31,10 @@ export const AudioSessionControls: React.FC<AudioSessionControlsProps> = ({ onSc
 
   const handleSceneUpdate = (updates: Partial<SceneControl>) => {
     updateSceneControl(updates);
-    
-    // Only call onSceneControl if we have all required properties
-    if (sceneControl && 
-        updates.arousal !== undefined && 
-        updates.valence !== undefined && 
-        updates.twist && 
-        updates.shards && 
-        updates.palette) {
-      onSceneControl?.({
-        arousal: updates.arousal,
-        valence: updates.valence,
-        twist: updates.twist,
-        shards: updates.shards,
-        palette: updates.palette
-      });
+
+    // Propagate the latest complete scene control state
+    if (sceneControl) {
+      onSceneControl?.(sceneControl);
     }
   };
 

--- a/src/components/Visualizer.tsx
+++ b/src/components/Visualizer.tsx
@@ -87,7 +87,7 @@ const Visualizer: React.FC<VisualizerProps> = ({ audioData, color }) => {
 
       mesh.instanceMatrix.needsUpdate = true;
       mesh.rotation.y += 0.002;
-      renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+      // Removed redundant pixel ratio update; it's set during initialization and resize
       renderer.render(scene, camera);
     };
     animate();
@@ -97,6 +97,7 @@ const Visualizer: React.FC<VisualizerProps> = ({ audioData, color }) => {
         camera.aspect = currentMount.clientWidth / currentMount.clientHeight;
         camera.updateProjectionMatrix();
         renderer.setSize(currentMount.clientWidth, currentMount.clientHeight);
+        renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
       }
     };
     window.addEventListener('resize', handleResize);

--- a/src/index.css
+++ b/src/index.css
@@ -261,3 +261,10 @@ select:focus {
     width: 100%;
   }
 }
+
+/* Global grid background pattern */
+.bg-grid-pattern {
+  background-image: linear-gradient(to right, rgba(107, 114, 128, 0.2) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(107, 114, 128, 0.2) 1px, transparent 1px);
+  background-size: 40px 40px;
+}

--- a/visual-3d.ts
+++ b/visual-3d.ts
@@ -9,9 +9,8 @@ import {Analyser} from './analyser';
 
 // Three.js Core
 import * as THREE from 'three';
+import { Mesh, IcosahedronGeometry, ConeGeometry, MeshBasicMaterial, AdditiveBlending } from 'three';
 import { createRenderer } from './renderer';
-
-// Import specific types from three
 
 // Three.js Extensions
 import { EXRLoader } from 'three/examples/jsm/loaders/EXRLoader.js';
@@ -68,8 +67,8 @@ export class GdmLiveAudioVisuals3D extends LitElement {
   private camera!: THREE.PerspectiveCamera;
   private controls!: OrbitControls;
   private composer!: EffectComposer;
-  private backdrop!: THREE.Mesh;
-  private sphere!: THREE.Mesh;
+  private backdrop!: Mesh;
+  private sphere!: Mesh;
   private controlGrid!: Float32Array;
   private controlPointsTexture!: THREE.Data3DTexture;
   private inputAnalyser!: Analyser;
@@ -142,8 +141,8 @@ export class GdmLiveAudioVisuals3D extends LitElement {
     const scene = new THREE.Scene();
     scene.background = new THREE.Color(0x100c14);
 
-    const backdrop = new THREE.Mesh(
-      new THREE.IcosahedronGeometry(10, 5),
+    const backdrop = new Mesh(
+      new IcosahedronGeometry(10, 5),
     );
     const material = new THREE.ShaderMaterial({
       uniforms: {
@@ -233,17 +232,17 @@ export class GdmLiveAudioVisuals3D extends LitElement {
       shader.vertexShader = sphereVS;
     };
 
-    const sphere = new THREE.Mesh(geometry, sphereMaterial);
+    const sphere = new Mesh(geometry, sphereMaterial);
     scene.add(sphere);
     sphere.visible = false;
 
     this.sphere = sphere;
 
     const lancetaCount = GRID_SIZE * GRID_SIZE * GRID_SIZE;
-    const lancetaGeometry = new THREE.ConeGeometry(0.02, 0.2, 4);
-    const lancetaMaterial = new THREE.MeshBasicMaterial({
+    const lancetaGeometry = new ConeGeometry(0.02, 0.2, 4);
+    const lancetaMaterial = new MeshBasicMaterial({
       color: 0xffaaff,
-      blending: THREE.AdditiveBlending as THREE.Blending,
+      blending: AdditiveBlending,
     });
     this.lancetas = new THREE.InstancedMesh(
       lancetaGeometry,


### PR DESCRIPTION
## Summary
- remove per-frame pixel ratio updates in Visualizer and set on resize instead
- simplify AudioSessionControls scene update propagation
- move grid pattern to global stylesheet and use Three.js named imports for clarity

## Testing
- `npm test` *(fails: No test files found)*
- `npm run validate:schemas`


------
https://chatgpt.com/codex/tasks/task_b_68b3c3f86e7c832f99ac97839a165357