### PR TITLE
refactor: optimize frequency data and scene updates

### DIFF
--- a/analyser.ts
+++ b/analyser.ts
@@ -28,8 +28,13 @@ export class Analyser {
     return this.dataArray;
   }
 
-  getFrequencyData(): number[] {
+  getFrequencyData(): Uint8Array {
     this.update();
-    return Array.from(this.dataArray);
+    return this.dataArray;
+  }
+
+  copyFrequencyData(targetArray: Uint8Array): void {
+    this.update();
+    targetArray.set(this.dataArray);
   }
 }

--- a/src/components/AudioSessionControls.tsx
+++ b/src/components/AudioSessionControls.tsx
@@ -31,11 +31,13 @@ export const AudioSessionControls: React.FC<AudioSessionControlsProps> = ({ onSc
 
   const handleSceneUpdate = (updates: Partial<SceneControl>) => {
     updateSceneControl(updates);
-
-    // Propagate the latest complete scene control state
-    if (sceneControl) {
-      onSceneControl?.(sceneControl);
-    }
+    const newSceneControl = {
+      ...sceneControl,
+      ...updates,
+      twist: { ...sceneControl?.twist, ...(updates.twist || {}) },
+      shards: { ...sceneControl?.shards, ...(updates.shards || {}) },
+    } as SceneControl;
+    onSceneControl?.(newSceneControl);
   };
 
   if (!isInitialized) {

--- a/visual-3d.ts
+++ b/visual-3d.ts
@@ -390,7 +390,7 @@ export class GdmLiveAudioVisuals3D extends LitElement {
 
     const material = this.backdrop.material as THREE.ShaderMaterial;
     material.uniforms.u_time.value = t;
-    material.uniforms.u_jitter.value = (Math.random() - 0.5) * 1e-3;
+    material.uniforms.u_jitter.value = (rand() - 0.5) * 1e-3;
 
     if (this.inputAnalyser) {
       const volume = this.getAverageVolume(this.inputAnalyser);


### PR DESCRIPTION
## Summary
- avoid frequency array allocations by returning Uint8Array and allow copying into a provided array
- propagate AudioSessionControls updates with merged state to ensure callback gets latest values
- seed jitter animation with deterministic random

## Testing
- `npm test` (fails: No test files found)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b83c9efa40832f908f5079c1e788c0